### PR TITLE
Redundant include from not found erlang path removed

### DIFF
--- a/lib/tasks/compile.bundlex.lib.ex
+++ b/lib/tasks/compile.bundlex.lib.ex
@@ -55,7 +55,7 @@ defmodule Mix.Tasks.Compile.Bundlex.Lib do
               _ ->
                 case erlang_includes do
                   nil -> []
-                  _ -> erlang_includes
+                  _ -> [erlang_includes]
                 end
             end
 


### PR DESCRIPTION
Below you can read about very strange findings and also some proposal of solution but I do not claim it's the best one - but it works.

It all started from the problem that once I got rid of lame library problem, I encountered "fatal error: erl_nif.h: Nie ma takiego pliku ani katalogu" even if erlang path was included in config.exs.

After some trials it occured that this is due to empty include generated in bundlex.sh (the first include below):

gcc -fPIC -W -O2 -g -I"" -I"../membrane_common_c/c_src" ...

Without the first include everything works fine. With that include erlang path erl_nif.h cannot be found.

After looking into bundlex code it occurred that there is a helper that looks for erlang path. Suprisingly erlang is installed in completely different path on my Ubuntu (don't know why but it becomes some kind of a rule - on my Ubuntu everything is somewhere else). But as I suspect it still should work if I add my erlang path to includes.

After investigation it occured that ErlangHelper.get_includes returns nil but if you add nil to includes, ie : [nil | includes] it ends up in -I"" generated in gcc command. The same thing happens if you add empty list [ [] | includes ] - my initial idea was to change DirectoryHelper.wildcard to return empty list instead of nil but since it didn't work I resigned from that idea.

So the proposal in the pull request doesn't add anything into the list if there are no erlang path hits.

Another interesting and error-prone thing I noticed is that if you return, list inside the list it gets falttened :

```
            includes = case nif_config |> List.keyfind(:includes, 0) do
              {:includes, includes} -> [erlang_includes|includes]
              _ -> [erlang_includes]
           end
```
As Path.wildcard returns list of binaries (it's already a list) so here we return list with list of binaries inside. If list contains only on element flattening won't be noticed. But if there are few hits  and few elements in the list it will end up in one big include. I did that for includes and it ended up in the following command:

gcc -fPIC -W -O2 -g -I"../membrane_common_c/c_src./deps/membrane_common_c/c_src/usr/lib/erlang/erts-8.3/include/"