### PR TITLE
Remove porcelain dependency

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,1 @@
 use Mix.Config
-
-config :porcelain, :driver, Porcelain.Driver.Basic

--- a/lib/bundlex/toolchain.ex
+++ b/lib/bundlex/toolchain.ex
@@ -47,4 +47,12 @@ defmodule Bundlex.Toolchain do
   def output_path(app_name, nif_name) do
     output_path(app_name) |> Path.join("#{nif_name}")
   end
+
+  @spec pkg_config(Bundlex.NIF.t(), [String.t()]) :: String.t()
+  def pkg_config(%Bundlex.NIF{pkg_configs: []}, _opts), do: ""
+
+  def pkg_config(%Bundlex.NIF{pkg_configs: packages}, opts) do
+    {output, 0} = System.cmd("pkg-config", opts ++ packages)
+    String.trim_trailing(output)
+  end
 end

--- a/lib/bundlex/toolchain/gcc.ex
+++ b/lib/bundlex/toolchain/gcc.ex
@@ -13,25 +13,8 @@ defmodule Bundlex.Toolchain.GCC do
 
     libs_part = nif.libs |> Enum.map(fn lib -> "-l#{lib}" end) |> Enum.join(" ")
 
-    pkg_config_libs_part =
-      nif.pkg_configs
-      |> Enum.map(fn pkg_config ->
-        %Porcelain.Result{status: 0, out: out} =
-          Porcelain.exec("pkg-config", ["--libs", pkg_config])
-
-        out |> String.trim()
-      end)
-      |> Enum.join(" ")
-
-    pkg_config_cflags_part =
-      nif.pkg_configs
-      |> Enum.map(fn pkg_config ->
-        %Porcelain.Result{status: 0, out: out} =
-          Porcelain.exec("pkg-config", ["--cflags", pkg_config])
-
-        out |> String.trim()
-      end)
-      |> Enum.join(" ")
+    pkg_config_libs_part = Toolchain.pkg_config(nif, ["--libs"])
+    pkg_config_cflags_part = Toolchain.pkg_config(nif, ["--cflags"])
 
     objects = nif.sources |> Enum.map(fn source -> object_path(source) end) |> Enum.join(" ")
 

--- a/lib/bundlex/toolchain/xcode.ex
+++ b/lib/bundlex/toolchain/xcode.ex
@@ -14,15 +14,7 @@ defmodule Bundlex.Toolchain.XCode do
     sources_part = nif.sources |> Enum.map(fn source -> "\"#{source}\"" end) |> Enum.join(" ")
     libs_part = nif.libs |> Enum.map(fn lib -> "-l#{lib}" end) |> Enum.join(" ")
 
-    pkg_configs_part =
-      nif.pkg_configs
-      |> Enum.map(fn pkg_config ->
-        %Porcelain.Result{status: 0, out: out} =
-          Porcelain.exec("pkg-config", ["--cflags", "--libs", pkg_config])
-
-        out |> String.trim()
-      end)
-      |> Enum.join(" ")
+    pkg_configs_part = Toolchain.pkg_config(nif, ["--cflags", "--libs"])
 
     [
       "mkdir -p #{Toolchain.output_path(app_name)}",

--- a/lib/tasks/compile.bundlex.ex
+++ b/lib/tasks/compile.bundlex.ex
@@ -11,7 +11,6 @@ defmodule Mix.Tasks.Compile.Bundlex do
 
   @spec run(OptionParser.argv()) :: :ok
   def run(_args) do
-    :ok = Application.ensure_started(:porcelain)
     :ok = MixHelper.store_project_dir()
 
     commands = []

--- a/mix.exs
+++ b/mix.exs
@@ -44,11 +44,8 @@ defmodule Bundlex.Mixfile do
   end
 
   defp deps() do
-    Application.put_env(:porcelain, :driver, Porcelain.Driver.Basic)
-
     [
       {:ex_doc, "~> 0.19", only: :dev, runtime: false},
-      {:porcelain, "~> 2.0"},
       {:bunch, "~> 0.1.2"}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -5,5 +5,4 @@
   "makeup": {:hex, :makeup, "0.5.1", "966c5c2296da272d42f1de178c1d135e432662eca795d6dc12e5e8787514edf7", [:mix], [{:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.8.0", "1204a2f5b4f181775a0e456154830524cf2207cf4f9112215c05e0b76e4eca8b", [:mix], [{:makeup, "~> 0.5.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.2.2", "d526b23bdceb04c7ad15b33c57c4526bf5f50aaa70c7c141b4b4624555c68259", [:mix], [], "hexpm"},
-  "porcelain": {:hex, :porcelain, "2.0.3", "2d77b17d1f21fed875b8c5ecba72a01533db2013bd2e5e62c6d286c029150fdc", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
The library doesn't use any advanced features of porcelain, which means the calls can be replaced by regular `System.cmd/3` calls.

Additionally, this takes advantage of the fact that `pkg_config` accepts a list of libraries and not just a single one, so the config string for all the libraries can be retrieved in just one call instead of library by library.

---

Since there aren't any tests in this package, I haven't tested the code beyond some basic manual sanity-checks. Please verify this before merging.