### PR TITLE
Fix build when system is using --as-needed flag

### DIFF
--- a/lib/bundlex/toolchain/common/unix.ex
+++ b/lib/bundlex/toolchain/common/unix.ex
@@ -26,7 +26,7 @@ defmodule Bundlex.Toolchain.Common.Unix do
       |> Enum.map(fn {source, object} ->
         """
         #{compile} -Wall -Wextra -c -std=c11 -O2 -g #{compiler_flags} \
-        -o #{path(object)} #{includes} #{pkg_config_cflags} #{path(source)}\
+        -o #{path(object)} #{includes} #{pkg_config_cflags} #{path(source)}
         """
       end)
 
@@ -53,15 +53,12 @@ defmodule Bundlex.Toolchain.Common.Unix do
       |> paths()
       |> wrap_deps.()
 
-    lib_dirs = native.lib_dirs |> paths("-L")
-    libs = native.libs |> Enum.map_join(" ", fn lib -> "-l#{lib}" end)
-    pkg_config_libs = native.pkg_configs |> pkg_config(:libs)
     linker_flags = native.linker_flags |> Enum.join(" ")
 
     [
       """
       #{link} #{linker_flags} -o #{path(output <> extension)} \
-      #{pkg_config_libs} #{lib_dirs} #{libs} #{deps} #{paths(objects)}
+      #{deps} #{paths(objects)} #{libs(native)}
       """
     ]
   end
@@ -73,6 +70,13 @@ defmodule Bundlex.Toolchain.Common.Unix do
   defp path(path) do
     path = path |> String.replace(~S("), ~S(\"))
     ~s("#{path}")
+  end
+
+  defp libs(native) do
+    lib_dirs = native.lib_dirs |> paths("-L")
+    libs = native.libs |> Enum.map_join(" ", fn lib -> "-l#{lib}" end)
+    pkg_config_libs = native.pkg_configs |> pkg_config(:libs)
+    "#{pkg_config_libs} #{lib_dirs} #{libs}"
   end
 
   defp pkg_config([], _options), do: ""


### PR DESCRIPTION
More info can be found [here](https://wiki.gentoo.org/wiki/Project:Quality_Assurance/As-needed#Failure_in_final_linking.2C_undefined_symbols) and [here](https://stackoverflow.com/a/409470/10186815)