### PR TITLE
Remove platform flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,6 @@ specified in bundlex project of this dependency.
 ### Compilation options
 
 The following command line arguments can be passed:
-- `--platform <platform>` - platform to build for, see `Bundlex.platform/0`.
 - `--store-scripts` - if set, shell scripts are stored in the project
 root folder for further analysis.
 

--- a/lib/bundlex.ex
+++ b/lib/bundlex.ex
@@ -7,12 +7,11 @@ defmodule Bundlex do
   alias Bundlex.Helper.MixHelper
 
   @doc """
-  Returns platform name passed by `--platform` command line argument or fallbacks
-  to the current platform name.
+  Returns current platform name.
   """
   @spec platform() :: :linux | :macosx | :windows32 | :windows64
   def platform() do
-    Platform.get_from_opts!()
+    Platform.get_current!()
   end
 
   @doc """

--- a/lib/bundlex/platform.ex
+++ b/lib/bundlex/platform.ex
@@ -34,28 +34,6 @@ defmodule Bundlex.Platform do
   end
 
   @doc """
-  Returns platform passed via `platform` option with fallback to the current
-  platform.
-
-  If retrieving the current platform fails, raises an error.
-
-  The first argument is a keyword list, as returned from `OptionParser.parse/2`
-  or `OptionParser.parse!/2`.
-  """
-  @spec get_from_opts!(OptionParser.parsed()) :: name_t
-  def get_from_opts!(
-        opts \\ OptionParser.parse(System.argv(), switches: [platform: :string]) |> elem(0)
-      ) do
-    platform = opts[:platform]
-
-    if platform do
-      String.to_atom(platform)
-    else
-      get_current!()
-    end
-  end
-
-  @doc """
   Detects current platform.
 
   In case of success returns platform name

--- a/lib/tasks/compile.bundlex.ex
+++ b/lib/tasks/compile.bundlex.ex
@@ -4,7 +4,6 @@ defmodule Mix.Tasks.Compile.Bundlex do
   #{@shortdoc}
 
   Accepts the following command line arguments:
-  - `--platform <platform>` - platform to build for, see `Bundlex.platform/0`.
   - `--store-scripts` - if set, shell scripts are stored in the project
   root folder for further analysis.
 


### PR DESCRIPTION
Fixes crash when starting OTP release created by Distillery