### PR TITLE
add compilation database generation

### DIFF
--- a/lib/bundlex/compilation_database.ex
+++ b/lib/bundlex/compilation_database.ex
@@ -1,0 +1,50 @@
+defmodule Bundlex.CompilationDatabase do
+  @moduledoc false
+
+  @file_name "compile_commands.json"
+
+  defmodule Object do
+    @moduledoc false
+
+    @type t :: %__MODULE__{
+            directory: String.t(),
+            file: String.t(),
+            command: String.t()
+          }
+
+    @derive Jason.Encoder
+
+    @enforce_keys [
+      :directory,
+      :file,
+      :command
+    ]
+    defstruct @enforce_keys
+
+    @spec from_command(command :: String.t()) :: Bunch.Type.try_t(t())
+    def from_command(command) do
+      {:ok, %__MODULE__{
+        directory: File.cwd!(),
+        file: "TODO",
+        command: command,
+      }}
+    end
+  end
+
+  @type t :: [Object.t()]
+
+  @type command_t :: String.t()
+
+  @spec new([command_t]) :: Bunch.Type.try_t(t)
+  def new(commands) do
+    Bunch.Enum.try_map(commands, &Object.from_command/1)
+  end
+
+  @spec store(db :: t, name :: String.t()) :: Bunch.Type.try_t(String.t())
+  def store(db, name \\ @file_name) do
+    with {:ok, json} <- Jason.encode(db, pretty: true),
+         :ok <- File.write(name, json) do
+      {:ok, name}
+    end
+  end
+end

--- a/lib/bundlex/compilation_database.ex
+++ b/lib/bundlex/compilation_database.ex
@@ -6,6 +6,8 @@ defmodule Bundlex.CompilationDatabase do
   defmodule Object do
     @moduledoc false
 
+    alias Bundlex.Toolchain
+
     @type t :: %__MODULE__{
             directory: String.t(),
             file: String.t(),
@@ -21,13 +23,43 @@ defmodule Bundlex.CompilationDatabase do
     ]
     defstruct @enforce_keys
 
-    @spec from_command(command :: String.t()) :: Bunch.Type.try_t(t())
+    @spec from_command(command :: String.t()) :: [t()]
     def from_command(command) do
-      {:ok, %__MODULE__{
-        directory: File.cwd!(),
-        file: "TODO",
-        command: command,
-      }}
+      # HACK This is a pretty hacked out implementation, that should never be
+      # published as release code. Ideally we should rework our Toolchain/command generation
+      # code to generate "rules" and "builds" with multiple "inputs" and "outputs",
+      # similarly to how Ninja works. Eventually we night adapt such model to generate
+      # Ninja build scripts and use Ninja itself to perform real builds of user code.
+
+      # This implementation assumes that the source file is always passed as the last argument
+      # to the compiler, which happens to be true on Linux and macOS.
+
+      compilers =
+        case Bundlex.platform() do
+          :linux -> Toolchain.GCC.compilers()
+          :macosx -> Toolchain.XCode.compilers()
+          _ -> raise "Generating compilation database is unsupported yet on this platform."
+        end
+        |> Map.from_struct()
+        |> Map.values()
+
+      command = command |> String.trim()
+
+      with true <- Enum.any?(compilers, &String.starts_with?(command, &1)),
+           file =
+             command
+             |> OptionParser.split()
+             |> List.last(),
+           true <- Path.extname(file) != ".o",
+           object = %__MODULE__{
+             directory: File.cwd!(),
+             file: file,
+             command: command
+           } do
+        [object]
+      else
+        _ -> []
+      end
     end
   end
 
@@ -35,9 +67,9 @@ defmodule Bundlex.CompilationDatabase do
 
   @type command_t :: String.t()
 
-  @spec new([command_t]) :: Bunch.Type.try_t(t)
+  @spec new([command_t]) :: t
   def new(commands) do
-    Bunch.Enum.try_map(commands, &Object.from_command/1)
+    Enum.flat_map(commands, &Object.from_command/1)
   end
 
   @spec store(db :: t, name :: String.t()) :: Bunch.Type.try_t(String.t())

--- a/lib/bundlex/toolchain/gcc.ex
+++ b/lib/bundlex/toolchain/gcc.ex
@@ -5,7 +5,7 @@ defmodule Bundlex.Toolchain.GCC do
   alias Bundlex.Native
   alias Bundlex.Toolchain.Common.{Unix, Compilers}
 
-  @compilers %Compilers{c: "gcc", cpp: "g++"}
+  def compilers, do: %Compilers{c: "gcc", cpp: "g++"}
 
   @impl Toolchain
   def compiler_commands(native) do
@@ -16,7 +16,7 @@ defmodule Bundlex.Toolchain.GCC do
         %Native{} -> {"", ""}
       end
 
-    compiler = @compilers |> Map.get(native.language)
+    compiler = compilers() |> Map.get(native.language)
 
     Unix.compiler_commands(
       native,

--- a/lib/bundlex/toolchain/xcode.ex
+++ b/lib/bundlex/toolchain/xcode.ex
@@ -5,7 +5,7 @@ defmodule Bundlex.Toolchain.XCode do
   alias Bundlex.Native
   alias Bundlex.Toolchain.Common.{Unix, Compilers}
 
-  @compilers %Compilers{c: "cc", cpp: "clang++"}
+  def compilers, do: %Compilers{c: "cc", cpp: "clang++"}
 
   @impl Toolchain
   def compiler_commands(native) do
@@ -21,7 +21,7 @@ defmodule Bundlex.Toolchain.XCode do
           {"", ""}
       end
 
-    compiler = @compilers |> Map.get(native.language)
+    compiler = compilers() |> Map.get(native.language)
 
     Unix.compiler_commands(
       native,

--- a/lib/tasks/compile.bundlex.ex
+++ b/lib/tasks/compile.bundlex.ex
@@ -55,17 +55,17 @@ defmodule Mix.Tasks.Compile.Bundlex do
       Output.info("Stored build script at #{File.cwd!() |> Path.join(filename)}")
     end
 
-    case build_script |> BuildScript.run(platform) do
+    case BuildScript.run(build_script, platform) do
       :ok ->
-        :ok
+        {:ok, []}
 
       {:error, {:run_build_script, return_code: ret, command: cmd}} ->
         Output.raise("Build script:\n\n#{cmd}\n\nreturned non-zero code: #{ret}")
+        {:error, []}
 
       {:error, reason} ->
         Output.raise("Error running build script, reason #{inspect(reason)}")
+        {:error, []}
     end
-
-    :ok
   end
 end

--- a/lib/tasks/compile.bundlex.ex
+++ b/lib/tasks/compile.bundlex.ex
@@ -16,7 +16,6 @@ defmodule Mix.Tasks.Compile.Bundlex do
   """
 
   use Mix.Task.Compiler
-  use Bunch
   alias Bundlex.{BuildScript, CompilationDatabase, Native, Output, Platform, Project}
   alias Bundlex.Helper.MixHelper
 
@@ -68,14 +67,13 @@ defmodule Mix.Tasks.Compile.Bundlex do
     end
 
     if cmdline_options[:store_compiledb] do
-      withl new: {:ok, db} <- CompilationDatabase.new(commands),
-            store: {:ok, filename} <- CompilationDatabase.store(db) do
-        Output.info("Stored compilation database as #{File.cwd!() |> Path.join(filename)}")
-      else
-        new: {:error, reason} ->
-          Output.raise("Failed to generate compilation database:\n\n#{reason}")
+      db = CompilationDatabase.new(commands)
 
-        store: {:error, reason} ->
+      case CompilationDatabase.store(db) do
+        {:ok, filename} ->
+          Output.info("Stored compilation database as #{File.cwd!() |> Path.join(filename)}")
+
+        {:error, reason} ->
           Output.raise("Failed to create compile_commands.json:\n\n#{reason}")
       end
     end

--- a/mix.exs
+++ b/mix.exs
@@ -56,6 +56,7 @@ defmodule Bundlex.Mixfile do
       {:bunch, "~> 1.0"},
       {:qex, "~> 0.5"},
       {:secure_random, "~> 0.5"},
+      {:jason, "~> 1.2"},
       {:dialyxir, "~> 1.0.0", only: [:dev], runtime: false}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,58 +1,16 @@
 %{
-  bunch:
-    {:hex, :bunch, "1.3.0", "51b4423088b7fb9e21eae6d6bc5e5d219d955ea5556fbd6130bfb6213df4be32",
-     [:mix], [], "hexpm", "9ad233a2bacc0dae8aa6553a9b9057f27446443b1c5903c3479b6f9f3820ce2d"},
-  bunch_native:
-    {:hex, :bunch_native, "0.2.1",
-     "0227d2a751a32f8c0b77dfec57c8dc7216351720c9c755c467e6d9387467fd1f", [:mix],
-     [{:bundlex, "~> 0.2.7", [hex: :bundlex, repo: "hexpm", optional: false]}], "hexpm",
-     "f0819b2f9f78086447ac7459a8e7b6e25ad535b9d3a4f9469253c552137de6b4"},
-  dialyxir:
-    {:hex, :dialyxir, "1.0.0", "6a1fa629f7881a9f5aaf3a78f094b2a51a0357c843871b8bc98824e7342d00a5",
-     [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm",
-     "aeb06588145fac14ca08d8061a142d52753dbc2cf7f0d00fc1013f53f8654654"},
-  earmark:
-    {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd",
-     [:mix], [], "hexpm", "8cf8a291ebf1c7b9539e3cddb19e9cef066c2441b1640f13c34c1d3cfc825fec"},
-  erlex:
-    {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e",
-     [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
-  ex_doc:
-    {:hex, :ex_doc, "0.21.3", "857ec876b35a587c5d9148a2512e952e24c24345552259464b98bfbb883c7b42",
-     [:mix],
-     [
-       {:earmark, "~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]},
-       {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}
-     ], "hexpm", "0db1ee8d1547ab4877c5b5dffc6604ef9454e189928d5ba8967d4a58a801f161"},
-  makeup:
-    {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc",
-     [:mix],
-     [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}],
-     "hexpm", "a10c6eb62cca416019663129699769f0c2ccf39428b3bb3c0cb38c718a0c186d"},
-  makeup_elixir:
-    {:hex, :makeup_elixir, "0.14.0",
-     "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix],
-     [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm",
-     "d4b316c7222a85bbaa2fd7c6e90e37e953257ad196dc229505137c5e505e9eff"},
-  nimble_parsec:
-    {:hex, :nimble_parsec, "0.5.3",
-     "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm",
-     "589b5af56f4afca65217a1f3eb3fee7e79b09c40c742fddc1c312b3ac0b3399f"},
-  qex:
-    {:hex, :qex, "0.5.0", "5a3a9becf67d4006377c4c247ffdaaa8ae5b3634a0caadb788dc24d6125068f4",
-     [:mix], [], "hexpm", "4ad6f6421163cd8204509a119a5c9813cbb969cfb8d802a9dc49b968bffbac2a"},
-  secure_random:
-    {:hex, :secure_random, "0.5.1",
-     "c5532b37c89d175c328f5196a0c2a5680b15ebce3e654da37129a9fe40ebf51b", [:mix], [], "hexpm",
-     "1b9754f15e3940a143baafd19da12293f100044df69ea12db5d72878312ae6ab"},
-  shmex:
-    {:hex, :shmex, "0.2.1", "f60f4edc85e514d131ceff1acd37a2b3ff8e77c88d7c04a05b8ab2ba454a1a40",
-     [:mix],
-     [
-       {:bunch_native, "~> 0.2.0", [hex: :bunch_native, repo: "hexpm", optional: false]},
-       {:bundlex, "~> 0.2.8", [hex: :bundlex, repo: "hexpm", optional: false]}
-     ], "hexpm", "8e75c2e2fd5735b57a66384ee4e9adb2888675074eacf01c63b71032387d4c65"},
-  unifex:
-    {:git, "https://github.com/membraneframework/unifex",
-     "213c1b9a1c18c64b8f4b2b50e647c96afe34c30e", [branch: "natives-spec"]}
+  "bunch": {:hex, :bunch, "1.3.0", "51b4423088b7fb9e21eae6d6bc5e5d219d955ea5556fbd6130bfb6213df4be32", [:mix], [], "hexpm", "9ad233a2bacc0dae8aa6553a9b9057f27446443b1c5903c3479b6f9f3820ce2d"},
+  "bunch_native": {:hex, :bunch_native, "0.2.1", "0227d2a751a32f8c0b77dfec57c8dc7216351720c9c755c467e6d9387467fd1f", [:mix], [{:bundlex, "~> 0.2.7", [hex: :bundlex, repo: "hexpm", optional: false]}], "hexpm", "f0819b2f9f78086447ac7459a8e7b6e25ad535b9d3a4f9469253c552137de6b4"},
+  "dialyxir": {:hex, :dialyxir, "1.0.0", "6a1fa629f7881a9f5aaf3a78f094b2a51a0357c843871b8bc98824e7342d00a5", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "aeb06588145fac14ca08d8061a142d52753dbc2cf7f0d00fc1013f53f8654654"},
+  "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm", "8cf8a291ebf1c7b9539e3cddb19e9cef066c2441b1640f13c34c1d3cfc825fec"},
+  "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
+  "ex_doc": {:hex, :ex_doc, "0.21.3", "857ec876b35a587c5d9148a2512e952e24c24345552259464b98bfbb883c7b42", [:mix], [{:earmark, "~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "0db1ee8d1547ab4877c5b5dffc6604ef9454e189928d5ba8967d4a58a801f161"},
+  "jason": {:hex, :jason, "1.2.1", "12b22825e22f468c02eb3e4b9985f3d0cb8dc40b9bd704730efa11abd2708c44", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "b659b8571deedf60f79c5a608e15414085fa141344e2716fbd6988a084b5f993"},
+  "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "a10c6eb62cca416019663129699769f0c2ccf39428b3bb3c0cb38c718a0c186d"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "d4b316c7222a85bbaa2fd7c6e90e37e953257ad196dc229505137c5e505e9eff"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.3", "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm", "589b5af56f4afca65217a1f3eb3fee7e79b09c40c742fddc1c312b3ac0b3399f"},
+  "qex": {:hex, :qex, "0.5.0", "5a3a9becf67d4006377c4c247ffdaaa8ae5b3634a0caadb788dc24d6125068f4", [:mix], [], "hexpm", "4ad6f6421163cd8204509a119a5c9813cbb969cfb8d802a9dc49b968bffbac2a"},
+  "secure_random": {:hex, :secure_random, "0.5.1", "c5532b37c89d175c328f5196a0c2a5680b15ebce3e654da37129a9fe40ebf51b", [:mix], [], "hexpm", "1b9754f15e3940a143baafd19da12293f100044df69ea12db5d72878312ae6ab"},
+  "shmex": {:hex, :shmex, "0.2.1", "f60f4edc85e514d131ceff1acd37a2b3ff8e77c88d7c04a05b8ab2ba454a1a40", [:mix], [{:bunch_native, "~> 0.2.0", [hex: :bunch_native, repo: "hexpm", optional: false]}, {:bundlex, "~> 0.2.8", [hex: :bundlex, repo: "hexpm", optional: false]}], "hexpm", "8e75c2e2fd5735b57a66384ee4e9adb2888675074eacf01c63b71032387d4c65"},
+  "unifex": {:git, "https://github.com/membraneframework/unifex", "213c1b9a1c18c64b8f4b2b50e647c96afe34c30e", [branch: "natives-spec"]},
 }


### PR DESCRIPTION
**This is a pretty hacked out implementation, that should never be published as release code.**

Ideally we should rework our Toolchain/command generation code to generate "rules" and "builds" with multiple "inputs" and "outputs", similarly to how Ninja works. Eventually we night adapt such model to generate Ninja build scripts and use Ninja itself to perform real builds of user code (see #39).

fix #68 