### PR TITLE
Secure the cookie: Passing the erlang cookie per environment.

### DIFF
--- a/lib/bundlex/cnode.ex
+++ b/lib/bundlex/cnode.ex
@@ -55,7 +55,7 @@ defmodule Bundlex.CNode do
   - host name,
   - alive name,
   - node name,
-  - cookie or empty (if cookie is passed in ERLANG_COOKIE environment variable),
+  - cookie or empty (if cookie is passed in BUNDLEX_ERLANG_COOKIE environment variable),
   - creation number.
 
   After CNode startup, these parameters should be passed to
@@ -95,13 +95,14 @@ defmodule Bundlex.CNode do
     do_start(app, native_name, false)
   end
 
-  defp cookie_env?(app,native_name) do 
+  defp cookie_env?(app, native_name) do
     cookie_env = Application.get_env(app, :cookie_env)
-    cond do 
+
+    cond do
       is_boolean(cookie_env) -> cookie_env
-      is_map(cookie_env) && is_boolean(cookie_env[native_name]) -> cookie_env[native_name]   
+      is_map(cookie_env) && is_boolean(cookie_env[native_name]) -> cookie_env[native_name]
       is_nil(cookie_env) && app == :bundlex -> false
-      app != :bundlex -> cookie_env?(:bundlex,native_name)
+      app != :bundlex -> cookie_env?(:bundlex, native_name)
       true -> false
     end
   end
@@ -110,7 +111,13 @@ defmodule Bundlex.CNode do
     {:ok, pid} =
       GenServer.start(
         __MODULE__.Server,
-        %{app: app, native_name: native_name, caller: self(), link?: link?, env?: cookie_env?(app,native_name)}
+        %{
+          app: app,
+          native_name: native_name,
+          caller: self(),
+          link?: link?,
+          cookie_env?: cookie_env?(app, native_name)
+        }
       )
 
     receive do

--- a/lib/bundlex/cnode.ex
+++ b/lib/bundlex/cnode.ex
@@ -89,29 +89,11 @@ defmodule Bundlex.CNode do
     do_start(app, native_name, false)
   end
 
-  defp cookie_env?(app, native_name) do
-    cookie_env = Application.get_env(app, :cookie_env)
-
-    cond do
-      is_boolean(cookie_env) -> cookie_env
-      is_map(cookie_env) && is_boolean(cookie_env[native_name]) -> cookie_env[native_name]
-      is_nil(cookie_env) && app == :bundlex -> false
-      app != :bundlex -> cookie_env?(:bundlex, native_name)
-      true -> false
-    end
-  end
-
   defp do_start(app, native_name, link?) do
     {:ok, pid} =
       GenServer.start(
         __MODULE__.Server,
-        %{
-          app: app,
-          native_name: native_name,
-          caller: self(),
-          link?: link?,
-          cookie_env?: cookie_env?(app, native_name)
-        }
+        %{app: app, native_name: native_name, caller: self(), link?: link?}
       )
 
     receive do

--- a/lib/bundlex/cnode.ex
+++ b/lib/bundlex/cnode.ex
@@ -89,10 +89,11 @@ defmodule Bundlex.CNode do
   end
 
   defp do_start(app, native_name, link?) do
+    env? = Application.get_env(app, :cookie_env, false)
     {:ok, pid} =
       GenServer.start(
         __MODULE__.Server,
-        %{app: app, native_name: native_name, caller: self(), link?: link?}
+        %{app: app, native_name: native_name, caller: self(), link?: link?, env?: env?}
       )
 
     receive do

--- a/lib/bundlex/cnode.ex
+++ b/lib/bundlex/cnode.ex
@@ -55,7 +55,6 @@ defmodule Bundlex.CNode do
   - host name,
   - alive name,
   - node name,
-  - cookie or empty (if cookie is passed in BUNDLEX_ERLANG_COOKIE environment variable),
   - creation number.
 
   After CNode startup, these parameters should be passed to
@@ -74,12 +73,7 @@ defmodule Bundlex.CNode do
   (this line is captured and not forwarded to the stdout).
   1. Connects to the CNode.
 
-  the config options can be used to pass the erlang cookie using an environment variable
-  ```
-  config :bundlex :cookie_env false # set a global default, pass by arguments
-  config :your_app :cookie_env true # override in your_app
-  config :your_app :cookie_env %{native_name: true} # override in your_app for a specific cnode binary
-  ```
+  The erlang cookie is passed using the BUNDLEX_ERLANG_COOKIE an environment variable.
   """
   @spec start_link(app :: atom, native_name :: atom) :: on_start_t
   def start_link(app, native_name) do

--- a/lib/bundlex/cnode/server.ex
+++ b/lib/bundlex/cnode/server.ex
@@ -12,15 +12,17 @@ defmodule Bundlex.CNode.Server do
     :ok = ensure_node_distributed()
     {name, creation} = NameStore.get_name()
     cnode = :"#{name}@#{host_name()}"
-    cookie_argument = unless opts.env?, do: Node.get_cookie(), else: ""
-    environment= if opts.env?, do: [{'ERLANG_COOKIE', Atom.to_charlist(Node.get_cookie)} ],else: []
+    cookie = unless opts.env?, do: Node.get_cookie(), else: ""
+
+    env =
+      if opts.env?, do: [{'BUNDLEX_ERLANG_COOKIE', Atom.to_charlist(Node.get_cookie())}], else: []
 
     port =
       Port.open(
         {:spawn_executable, Bundlex.build_path(opts.app, opts.native_name, :cnode)},
-        args: [host_name(), name, cnode, cookie_argument, "#{creation}"],
+        args: [host_name(), name, cnode, cookie, "#{creation}"],
         line: 2048,
-        env: environment
+        env: env
       )
 
     Process.send_after(self(), :timeout, 5000)

--- a/lib/bundlex/cnode/server.ex
+++ b/lib/bundlex/cnode/server.ex
@@ -12,17 +12,14 @@ defmodule Bundlex.CNode.Server do
     :ok = ensure_node_distributed()
     {name, creation} = NameStore.get_name()
     cnode = :"#{name}@#{host_name()}"
-    cookie = unless opts.cookie_env?, do: Node.get_cookie(), else: ""
-
-    env =
-      if opts.cookie_env?, do: [{'BUNDLEX_ERLANG_COOKIE', Atom.to_charlist(Node.get_cookie())}], else: []
+    cookie = Node.get_cookie() |> Atom.to_charlist()
 
     port =
       Port.open(
         {:spawn_executable, Bundlex.build_path(opts.app, opts.native_name, :cnode)},
-        args: [host_name(), name, cnode, cookie, "#{creation}"],
+        args: [host_name(), name, cnode, "#{creation}"],
         line: 2048,
-        env: env
+        env: [{'BUNDLEX_ERLANG_COOKIE', cookie}]
       )
 
     Process.send_after(self(), :timeout, 5000)

--- a/lib/bundlex/cnode/server.ex
+++ b/lib/bundlex/cnode/server.ex
@@ -12,10 +12,10 @@ defmodule Bundlex.CNode.Server do
     :ok = ensure_node_distributed()
     {name, creation} = NameStore.get_name()
     cnode = :"#{name}@#{host_name()}"
-    cookie = unless opts.env?, do: Node.get_cookie(), else: ""
+    cookie = unless opts.cookie_env?, do: Node.get_cookie(), else: ""
 
     env =
-      if opts.env?, do: [{'BUNDLEX_ERLANG_COOKIE', Atom.to_charlist(Node.get_cookie())}], else: []
+      if opts.cookie_env?, do: [{'BUNDLEX_ERLANG_COOKIE', Atom.to_charlist(Node.get_cookie())}], else: []
 
     port =
       Port.open(

--- a/lib/bundlex/cnode/server.ex
+++ b/lib/bundlex/cnode/server.ex
@@ -12,12 +12,15 @@ defmodule Bundlex.CNode.Server do
     :ok = ensure_node_distributed()
     {name, creation} = NameStore.get_name()
     cnode = :"#{name}@#{host_name()}"
+    cookie_argument = unless opts.env?, do: Node.get_cookie(), else: ""
+    environment= if opts.env?, do: [{'ERLANG_COOKIE', Atom.to_charlist(Node.get_cookie)} ],else: []
 
     port =
       Port.open(
         {:spawn_executable, Bundlex.build_path(opts.app, opts.native_name, :cnode)},
-        args: [host_name(), name, cnode, Node.get_cookie(), "#{creation}"],
-        line: 2048
+        args: [host_name(), name, cnode, cookie_argument, "#{creation}"],
+        line: 2048,
+        env: environment
       )
 
     Process.send_after(self(), :timeout, 5000)

--- a/test_projects/example/c_src/example/example_cnode.c
+++ b/test_projects/example/c_src/example/example_cnode.c
@@ -119,7 +119,7 @@ int main(int argc, char **argv) {
   if(*argv[4] != '\0') 
     strcpy(cookie, argv[4]);
   else
-    strcpy(cookie, getenv("ERLANG_COOKIE"));
+    strcpy(cookie, getenv("BUNDLEX_ERLANG_COOKIE"));
   short creation = (short)atoi(argv[5]);
 
   int listen_fd;

--- a/test_projects/example/c_src/example/example_cnode.c
+++ b/test_projects/example/c_src/example/example_cnode.c
@@ -116,7 +116,6 @@ int main(int argc, char **argv) {
   char node_name[256];
   strcpy(node_name, argv[3]);
   short creation = (short)atoi(argv[4]);
-  
   char *cookie = getenv("BUNDLEX_ERLANG_COOKIE");
 
   int listen_fd;

--- a/test_projects/example/c_src/example/example_cnode.c
+++ b/test_projects/example/c_src/example/example_cnode.c
@@ -116,7 +116,10 @@ int main(int argc, char **argv) {
   char node_name[256];
   strcpy(node_name, argv[3]);
   char cookie[256];
-  strcpy(cookie, argv[4]);
+  if(*argv[4] != '\0') 
+    strcpy(cookie, argv[4]);
+  else
+    strcpy(cookie, getenv("ERLANG_COOKIE"));
   short creation = (short)atoi(argv[5]);
 
   int listen_fd;

--- a/test_projects/example/c_src/example/example_cnode.c
+++ b/test_projects/example/c_src/example/example_cnode.c
@@ -98,7 +98,7 @@ int receive(int ei_fd, char *node_name) {
 }
 
 int validate_args(int argc, char **argv) {
-  assert(argc == 6);
+  assert(argc == 5);
   for (int i = 1; i < argc; i++) {
     assert(strlen(argv[i]) < 255);
   }
@@ -115,12 +115,9 @@ int main(int argc, char **argv) {
   strcpy(alive_name, argv[2]);
   char node_name[256];
   strcpy(node_name, argv[3]);
-  char cookie[256];
-  if(*argv[4] != '\0') 
-    strcpy(cookie, argv[4]);
-  else
-    strcpy(cookie, getenv("BUNDLEX_ERLANG_COOKIE"));
-  short creation = (short)atoi(argv[5]);
+  short creation = (short)atoi(argv[4]);
+  
+  char *cookie = getenv("BUNDLEX_ERLANG_COOKIE");
 
   int listen_fd;
   int port;

--- a/test_projects/example/test/example_test.exs
+++ b/test_projects/example/test/example_test.exs
@@ -17,6 +17,7 @@ defmodule ExampleTest do
 
       defnif(bar(a, b))
     end
+
     assert 0 = Bar.bar(5, 5)
   end
 
@@ -26,10 +27,6 @@ defmodule ExampleTest do
 
   test "cnode without interface" do
     test_cnode(:example_cnode)
-  end
-
-  test ":cookie_env mechanism" do
-    test_cnode(:example,true)
   end
 
   test "native with interface port" do
@@ -49,12 +46,10 @@ defmodule ExampleTest do
     end
   end
 
-  defp test_cnode(name,cookie_env? \\ false) do
+  defp test_cnode(name) do
     require Bundlex.CNode
-    Application.put_env(:example,:cookie_env,Map.put(%{},name,cookie_env?))
     assert {:ok, cnode} = Bundlex.CNode.start_link(name)
     assert 10.0 = Bundlex.CNode.call(cnode, {:foo, 5.0, 5.0})
-    Application.delete_env(:example,:cookie_env)
   end
 
   defp test_port(name) do

--- a/test_projects/example/test/example_test.exs
+++ b/test_projects/example/test/example_test.exs
@@ -28,12 +28,8 @@ defmodule ExampleTest do
     test_cnode(:example_cnode)
   end
 
-  test "native with interface CNode with ERLANG_COOKIE environment" do
+  test ":cookie_env mechanism" do
     test_cnode(:example,true)
-  end
-
-  test "cnode without interface with ERLANG_COOKIE environment" do
-    test_cnode(:example_cnode,true)
   end
 
   test "native with interface port" do

--- a/test_projects/example/test/example_test.exs
+++ b/test_projects/example/test/example_test.exs
@@ -17,7 +17,6 @@ defmodule ExampleTest do
 
       defnif(bar(a, b))
     end
-
     assert 0 = Bar.bar(5, 5)
   end
 
@@ -27,6 +26,14 @@ defmodule ExampleTest do
 
   test "cnode without interface" do
     test_cnode(:example_cnode)
+  end
+
+  test "native with interface CNode with ERLANG_COOKIE environment" do
+    test_cnode(:example,true)
+  end
+
+  test "cnode without interface with ERLANG_COOKIE environment" do
+    test_cnode(:example_cnode,true)
   end
 
   test "native with interface port" do
@@ -46,10 +53,12 @@ defmodule ExampleTest do
     end
   end
 
-  defp test_cnode(name) do
+  defp test_cnode(name,cookie_env? \\ false) do
     require Bundlex.CNode
+    Application.put_env(:example,:cookie_env,Map.put(%{},name,cookie_env?))
     assert {:ok, cnode} = Bundlex.CNode.start_link(name)
     assert 10.0 = Bundlex.CNode.call(cnode, {:foo, 5.0, 5.0})
+    Application.delete_env(:example,:cookie_env)
   end
 
   defp test_port(name) do


### PR DESCRIPTION
Passing the Erlang cookie in process arguments leaks the cookie in process listings.
as arguments can be observed by process monitoring tools.

Passing secrets via environment variables does not have this problem.

This patch adds support for configuring the use of an **ERLANG_COOKIE** environment variable. Passing via environment is made configurable for CNodes.

```elixir
        # config.exs
        config :bundlex :cookie_env  true # global setting false by default
        config :my_app  :cookie_env  true # override per application
        config :my_app  :cookie_env  %{a_native_name: true} # individualy
```
when set to true, the CNode is started with an empty cookie argument, and the ERLANG_COOKIE variable set.

* does not change the default behavior
* updated the the example CNode to detect an empty cookie argument and use the environment variable in this case.
* Added test cases for the updated behavior

