### PR TITLE
Fix dialyzer warnings

### DIFF
--- a/lib/bundlex/cnode/server.ex
+++ b/lib/bundlex/cnode/server.ex
@@ -31,6 +31,8 @@ defmodule Bundlex.CNode.Server do
        cnode: cnode,
        msg_part?: false
      }}
+  catch
+    err, reason -> {:stop, {err, reason}}
   end
 
   @impl true

--- a/lib/bundlex/output.ex
+++ b/lib/bundlex/output.ex
@@ -5,6 +5,7 @@ defmodule Bundlex.Output do
     Mix.shell().info("Bundlex: " <> msg)
   end
 
+  @spec raise(term()) :: no_return()
   def raise(msg) do
     Mix.raise("Bundlex: " <> msg)
   end

--- a/lib/bundlex/output.ex
+++ b/lib/bundlex/output.ex
@@ -5,7 +5,7 @@ defmodule Bundlex.Output do
     Mix.shell().info("Bundlex: " <> msg)
   end
 
-  @spec raise(term()) :: no_return()
+  @spec raise(binary()) :: no_return()
   def raise(msg) do
     Mix.raise("Bundlex: " <> msg)
   end


### PR DESCRIPTION
`Bundlex.CNode.Server.init/1` fail if `Port.open/2` fails, violating the inferred spec.
Fixed by handling failure

`Bundlex.Output.raise/1'` does not return by design. 
Added type annotation to tell dialyzer.

Fixes #77