### PR TITLE
use nif_error to avoid no_return from dialyzer

### DIFF
--- a/lib/bundlex/loader.ex
+++ b/lib/bundlex/loader.ex
@@ -60,7 +60,7 @@ defmodule Bundlex.Loader do
 
         quote do
           def unquote(fun) do
-            raise "Nif fail: #{unquote(module)}.#{unquote(name)}/#{length(unquote(args))}"
+            :erlang.nif_error "Nif fail: #{unquote(module)}.#{unquote(name)}/#{length(unquote(args))}"
           end
         end
       end)


### PR DESCRIPTION
All my NIFs were raising `no_return` on Dialyzer, after some search, I found this solution to fix that problem

http://erlang.org/doc/man/erlang.html#nif_error-1