### PR TITLE
Remove default standard version, when compiler flags already define it

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ specified in Bundlex project of this dependency. Empty list by default. See _Dep
 for details.
 * `src_base` - Native files should reside in `project_root/c_src/<src_base>`
 (application name by default).
-* `compiler_flags` - Custom flags for compiler.
+* `compiler_flags` - Custom flags for compiler. Default `-std` flag for `:c` is `-std=c11` and for `:cpp` is `-std=c++17`. 
 * `linker_flags` - Custom flags for linker.
 * `language` - Language of native. `:c` or `:cpp` may be chosen (`:c` by default)
 * `interface` - Interface used to integrate with Elixir code. The following interfaces are available:

--- a/lib/bundlex/toolchain/common/compilers.ex
+++ b/lib/bundlex/toolchain/common/compilers.ex
@@ -6,14 +6,14 @@ defmodule Bundlex.Toolchain.Common.Compilers do
   defstruct @enforce_keys
 
   @doc """
-  Provides compiler flag specyfying language standard, each one for every supported language
+  Provides compiler flag specyfying default language standard, each one for every supported language
   """
-  @spec get_std_flag(atom) :: String.t()
-  def get_std_flag(:cpp) do
+  @spec get_default_std_flag(:c | :cpp) :: String.t()
+  def get_default_std_flag(:cpp) do
     "-std=c++17"
   end
 
-  def get_std_flag(:c) do
+  def get_default_std_flag(:c) do
     "-std=c11"
   end
 end


### PR DESCRIPTION
Solves https://membraneframework.atlassian.net/browse/MS-210

