### PR TITLE
Add ARM macs homebrew installation path to library search path

### DIFF
--- a/lib/bundlex/toolchain/common/unix/os_deps.ex
+++ b/lib/bundlex/toolchain/common/unix/os_deps.ex
@@ -138,7 +138,8 @@ defmodule Bundlex.Toolchain.Common.Unix.OSDeps do
 
     [
       "-L#{full_packages_library_path}",
-      "-Wl,-rpath,#{full_packages_library_path}"
+      "-Wl,-rpath,#{full_packages_library_path}",
+      "-Wl,-rpath,/opt/homebrew/lib"
     ] ++
       Enum.map(lib_names, &"-l#{remove_lib_prefix(&1)}")
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Bundlex.Mixfile do
   use Mix.Project
 
-  @version "1.4.1"
+  @version "1.4.2"
   @github_url "https://github.com/membraneframework/bundlex"
 
   def project do


### PR DESCRIPTION
Allow linker to locate libraries that were installed with brew on Macs with ARM architecture