### PR TITLE
Release v1.4.6 and bugfix of symlink to priv/ creation

### DIFF
--- a/lib/bundlex/toolchain/common/unix/os_deps.ex
+++ b/lib/bundlex/toolchain/common/unix/os_deps.ex
@@ -135,11 +135,12 @@ defmodule Bundlex.Toolchain.Common.Unix.OSDeps do
     logical_lib_path = Path.join(dep_path, "lib")
     {physical_lib_path, 0} = System.shell("realpath #{logical_lib_path}")
 
-    output_path = Bundlex.Toolchain.output_path(native.app, native.interface)
+    logical_output_path = Bundlex.Toolchain.output_path(native.app, native.interface)
+    {physical_output_path, 0} = System.shell("realpath #{logical_output_path}")
 
     physical_dep_dir_name = logical_dep_dir_name <> "_physical"
-    create_relative_symlink(logical_lib_path, output_path, logical_dep_dir_name)
-    create_relative_symlink(physical_lib_path, output_path, physical_dep_dir_name)
+    create_relative_symlink(logical_lib_path, logical_output_path, logical_dep_dir_name)
+    create_relative_symlink(physical_lib_path, physical_output_path, physical_dep_dir_name)
 
     # TODO: pass the platform via arguments
     # $ORIGIN must be escaped so that it's not treated as an ENV variable

--- a/lib/bundlex/toolchain/common/unix/os_deps.ex
+++ b/lib/bundlex/toolchain/common/unix/os_deps.ex
@@ -137,7 +137,7 @@ defmodule Bundlex.Toolchain.Common.Unix.OSDeps do
     create_relative_symlink(lib_path, logical_output_path, logical_dep_dir_name)
 
     {physical_output_path, 0} = System.shell("realpath #{logical_output_path}")
-    physical_output_path = String.slice(physical_output_path, 0..-2)
+    physical_output_path = String.slice(physical_output_path, 0..-2//1)
     physical_dep_dir_name = logical_dep_dir_name <> "_physical"
     create_relative_symlink(lib_path, physical_output_path, physical_dep_dir_name)
 

--- a/lib/bundlex/toolchain/common/unix/os_deps.ex
+++ b/lib/bundlex/toolchain/common/unix/os_deps.ex
@@ -136,9 +136,12 @@ defmodule Bundlex.Toolchain.Common.Unix.OSDeps do
     {physical_lib_path, 0} = System.shell("realpath #{logical_lib_path}")
 
     logical_output_path = Bundlex.Toolchain.output_path(native.app, native.interface)
-    {physical_output_path, 0} = System.shell("realpath #{logical_output_path}")
+    # {physical_output_path, 0} = System.shell("realpath #{logical_output_path}")
 
+    physical_lib_path = String.slice(physical_lib_path, 0..-2)
+    physical_output_path = logical_output_path
     physical_dep_dir_name = logical_dep_dir_name <> "_physical"
+
     create_relative_symlink(logical_lib_path, logical_output_path, logical_dep_dir_name)
     create_relative_symlink(physical_lib_path, physical_output_path, physical_dep_dir_name)
 

--- a/lib/bundlex/toolchain/common/unix/os_deps.ex
+++ b/lib/bundlex/toolchain/common/unix/os_deps.ex
@@ -132,18 +132,14 @@ defmodule Bundlex.Toolchain.Common.Unix.OSDeps do
   end
 
   defp get_precompiled_libs_flags(dep_path, logical_dep_dir_name, lib_names, native) do
-    logical_lib_path = Path.join(dep_path, "lib")
-    {physical_lib_path, 0} = System.shell("realpath #{logical_lib_path}")
-
+    lib_path = Path.join(dep_path, "lib")
     logical_output_path = Bundlex.Toolchain.output_path(native.app, native.interface)
-    # {physical_output_path, 0} = System.shell("realpath #{logical_output_path}")
+    create_relative_symlink(lib_path, logical_output_path, logical_dep_dir_name)
 
-    physical_lib_path = String.slice(physical_lib_path, 0..-2)
-    physical_output_path = logical_output_path
+    {physical_output_path, 0} = System.shell("realpath #{logical_output_path}")
+    physical_output_path = String.slice(physical_output_path, 0..-2)
     physical_dep_dir_name = logical_dep_dir_name <> "_physical"
-
-    create_relative_symlink(logical_lib_path, logical_output_path, logical_dep_dir_name)
-    create_relative_symlink(physical_lib_path, physical_output_path, physical_dep_dir_name)
+    create_relative_symlink(lib_path, physical_output_path, physical_dep_dir_name)
 
     # TODO: pass the platform via arguments
     # $ORIGIN must be escaped so that it's not treated as an ENV variable

--- a/lib/bundlex/toolchain/common/unix/os_deps.ex
+++ b/lib/bundlex/toolchain/common/unix/os_deps.ex
@@ -263,7 +263,7 @@ defmodule Bundlex.Toolchain.Common.Unix.OSDeps do
     unless File.exists?(symlink) do
       File.mkdir_p!(dir)
 
-      File.ln_s!(path_from_to(dir, target), symlink)
+      File.ln_s(path_from_to(dir, target), symlink)
     end
 
     :ok

--- a/lib/bundlex/toolchain/common/unix/os_deps.ex
+++ b/lib/bundlex/toolchain/common/unix/os_deps.ex
@@ -134,7 +134,9 @@ defmodule Bundlex.Toolchain.Common.Unix.OSDeps do
   defp get_precompiled_libs_flags(dep_path, dep_dir_name, lib_names, native) do
     lib_path = Path.join(dep_path, "lib")
     output_path = Bundlex.Toolchain.output_path(native.app, native.interface)
+    dep_dir_name2 = dep_dir_name <> "2"
     create_relative_symlink(lib_path, output_path, dep_dir_name)
+    create_relative_symlink(lib_path, output_path, dep_dir_name2)
 
     # TODO: pass the platform via arguments
     # $ORIGIN must be escaped so that it's not treated as an ENV variable
@@ -143,6 +145,7 @@ defmodule Bundlex.Toolchain.Common.Unix.OSDeps do
     [
       "-L#{Path.join(dep_path, "lib")}",
       "-Wl,-rpath,#{rpath_root}/#{dep_dir_name}",
+      "-Wl,-rpath,#{rpath_root}/#{dep_dir_name2}",
       "-Wl,-rpath,/opt/homebrew/lib"
     ] ++ Enum.map(lib_names, &"-l#{remove_lib_prefix(&1)}")
   end
@@ -262,7 +265,6 @@ defmodule Bundlex.Toolchain.Common.Unix.OSDeps do
 
     unless File.exists?(symlink) do
       File.mkdir_p!(dir)
-
       File.ln_s(path_from_to(dir, target), symlink)
     end
 

--- a/lib/bundlex/toolchain/common/unix/os_deps.ex
+++ b/lib/bundlex/toolchain/common/unix/os_deps.ex
@@ -136,8 +136,12 @@ defmodule Bundlex.Toolchain.Common.Unix.OSDeps do
     logical_output_path = Bundlex.Toolchain.output_path(native.app, native.interface)
     create_relative_symlink(lib_path, logical_output_path, logical_dep_dir_name)
 
+    # We create a second ("physical") symlink to the place where the precompiled dependencies
+    # are stored because we need to assure that the relative link in the symlink's target
+    # will work properly also when the symlink is put in the location, for which the
+    # logical path differs from the physical path
     {physical_output_path, 0} = System.shell("realpath #{logical_output_path}")
-    physical_output_path = String.slice(physical_output_path, 0..-2//1)
+    physical_output_path = String.trim_trailing(physical_output_path)
     physical_dep_dir_name = logical_dep_dir_name <> "_physical"
     create_relative_symlink(lib_path, physical_output_path, physical_dep_dir_name)
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Bundlex.Mixfile do
   use Mix.Project
 
-  @version "1.4.5"
+  @version "1.4.6"
   @github_url "https://github.com/membraneframework/bundlex"
 
   def project do


### PR DESCRIPTION
This PR:
* Makes the symlink to the directory with precompiled dependencies in priv/ creation not fail if the directory already exists.
* Sets the appropriate RPATH to precompiled dependencies directory in `.so` files for `priv/` in `_build` being both a directory and for a symlink
* Bumps the version to v1.4.6