### PR TITLE
Expand get_target to include crosscompilation

### DIFF
--- a/lib/bundlex.ex
+++ b/lib/bundlex.ex
@@ -15,25 +15,41 @@ defmodule Bundlex do
   * architecture - e.g. `x86_64` or `arm64`
   * vendor - e.g. `pc`
   * os - operating system, e.g. `linux` or `darwin20.6.0`
-  * abi - application binary interface, e.g. `musl` or `gnu` (nil if unknown / non-existent)
+  * abi - application binary interface, e.g. `musl` or `gnu`
   """
   @type target ::
-          %{architecture: String.t(), vendor: String.t(), os: String.t(), abi: String.t() | nil}
+          %{
+            architecture: String.t() | :unknown,
+            vendor: String.t() | :unknown,
+            os: String.t() | :unknown,
+            abi: String.t() | :unknown
+          }
 
   @doc """
-  A function returning a target triplet for the environment on which it is run.
+  A function returning information about the target platform (unknown in case of crosscompilation).
   """
   @spec get_target() :: target()
-  def get_target() do
-    [architecture, vendor, os | maybe_abi] =
-      :erlang.system_info(:system_architecture) |> List.to_string() |> String.split("-")
+  if Mix.target() == :host do
+    def get_target() do
+      [architecture, vendor, os | maybe_abi] =
+        :erlang.system_info(:system_architecture) |> List.to_string() |> String.split("-")
 
-    %{
-      architecture: architecture,
-      vendor: vendor,
-      os: os,
-      abi: List.first(maybe_abi)
-    }
+      %{
+        architecture: architecture,
+        vendor: vendor,
+        os: os,
+        abi: List.first(maybe_abi) || :unknown
+      }
+    end
+  else
+    def get_target() do
+      %{
+        architecture: :unknown,
+        vendor: :unknown,
+        os: :unknown,
+        abi: :unknown
+      }
+    end
   end
 
   @doc """


### PR DESCRIPTION
closes https://github.com/membraneframework/membrane_core/issues/721

Up until now there were two public functions that gave information about platform, `Bundlex.get_target/0` and `Bundlex.platform/0`. Their difference was that `get_target/0` gave more specific infomation, but later on, when adding crosscompilation support, only `platform/0` detected the crosscompilation.

This PR changes behavior of `Bundlex.get_target/0`, so that when crosscompiling the `target` map will have fields with value `:unknown`.

I'd also consider allowing for crosscompilation outside of nerves. The only thing nerves does is set env variables to correct flags and paths, which can be also done by the user that wants to use their custom toolchain