### PR TITLE
Stop Bundlex.Output calls in runtime

### DIFF
--- a/lib/bundlex.ex
+++ b/lib/bundlex.ex
@@ -78,7 +78,7 @@ defmodule Bundlex do
   """
   @spec family() :: :unix | :windows | :custom
   def family() do
-    Platform.family(platform())
+    Platform.family(Platform.get_target!())
   end
 
   @doc """

--- a/lib/bundlex/platform.ex
+++ b/lib/bundlex/platform.ex
@@ -86,18 +86,16 @@ defmodule Bundlex.Platform do
       end
 
     {:ok, _crosscompile} ->
-      def get_target!() do
-        case System.fetch_env("NERVES_APP") do
-          {:ok, _app} ->
-            :nerves
+      case System.fetch_env("NERVES_APP") do
+        {:ok, _app} ->
+          def get_target!(), do: :nerves
 
-          :error ->
-            Output.info(
-              "Cross-compiling without using Nerves. Make sure necessary environment variables are set correctly."
-            )
+        :error ->
+          Output.info(
+            "Cross-compiling without using Nerves. Make sure necessary environment variables are set correctly."
+          )
 
-            :custom
-        end
+          def get_target!(), do: :custom
       end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Bundlex.Mixfile do
   use Mix.Project
 
-  @version "1.5.0"
+  @version "1.5.1"
   @github_url "https://github.com/membraneframework/bundlex"
 
   def project do


### PR DESCRIPTION
The bug that caused nerves devices to not boot was bundlex trying to call `Mix.shell()` in runtime.