### PR TITLE
Fix msvc compilation

### DIFF
--- a/lib/bundlex.ex
+++ b/lib/bundlex.ex
@@ -36,8 +36,7 @@ defmodule Bundlex do
         platform when platform in [:windows32, :windows64] ->
           def get_target() do
             os = "windows"
-            <<^os::binary, architecture::binary>> = Atom.to_string(unquote(platform))
-            {architecture, ""} = Integer.parse(architecture)
+            architecture = System.fetch_env!("PROCESSOR_ARCHITECTURE")
             vendor = "pc"
 
             %{

--- a/lib/bundlex.ex
+++ b/lib/bundlex.ex
@@ -41,7 +41,6 @@ defmodule Bundlex do
             abi: "unknown"
           }
         end
-
       else
         def get_target() do
           [architecture, vendor, os | maybe_abi] =

--- a/lib/bundlex/build_script.ex
+++ b/lib/bundlex/build_script.ex
@@ -34,7 +34,7 @@ defmodule Bundlex.BuildScript do
 
   def run(%__MODULE__{commands: commands}, platform) do
     family = Platform.family(platform)
-    cmd = commands |> join_commands(family)
+    cmd = commands |> join_commands_run(family)
 
     case cmd |> Mix.shell().cmd() do
       0 -> :ok
@@ -54,6 +54,14 @@ defmodule Bundlex.BuildScript do
       {:ok, {script_name, script}}
     end
   end
+
+  # TODO: this is obviously awkward but I'm very tired.
+  # should the toolchains define these?
+  defp join_commands_run(commands, :windows) do
+    Enum.join(commands, " && ")
+  end
+
+  defp join_commands_run(commands, family), do: join_commands(commands, family)
 
   defp join_commands(commands, :windows) do
     Enum.join(commands, "\r\n") <> "\r\n"

--- a/lib/bundlex/build_script.ex
+++ b/lib/bundlex/build_script.ex
@@ -34,7 +34,7 @@ defmodule Bundlex.BuildScript do
 
   def run(%__MODULE__{commands: commands}, platform) do
     family = Platform.family(platform)
-    cmd = commands |> join_commands_run(family)
+    cmd = commands |> join_commands(family)
 
     case cmd |> Mix.shell().cmd() do
       0 -> :ok
@@ -55,16 +55,8 @@ defmodule Bundlex.BuildScript do
     end
   end
 
-  # TODO: this is obviously awkward but I'm very tired.
-  # should the toolchains define these?
-  defp join_commands_run(commands, :windows) do
-    Enum.join(commands, " && ")
-  end
-
-  defp join_commands_run(commands, family), do: join_commands(commands, family)
-
   defp join_commands(commands, :windows) do
-    Enum.join(commands, "\r\n") <> "\r\n"
+    Enum.join(commands, " && ") <> "\r\n"
   end
 
   defp join_commands(commands, _other) do

--- a/lib/bundlex/helper/path_helper.ex
+++ b/lib/bundlex/helper/path_helper.ex
@@ -3,15 +3,6 @@ defmodule Bundlex.Helper.PathHelper do
   # Module containing helper functions that ease traversing directories.
 
   @doc """
-  Tries to find a path that matches given pattern that has the biggest
-  version number if it is expected to be a suffix.
-  """
-  @spec latest_wildcard(String.t()) :: nil | String.t()
-  def latest_wildcard(pattern) do
-    pattern |> Path.wildcard() |> Enum.max(fn -> nil end)
-  end
-
-  @doc """
   Fixes slashes in the given path to match convention used on current
   operating system.
 

--- a/lib/bundlex/toolchain/visual_studio.ex
+++ b/lib/bundlex/toolchain/visual_studio.ex
@@ -16,7 +16,6 @@ defmodule Bundlex.Toolchain.VisualStudio do
   alias Bundlex.Native
   alias Bundlex.Output
 
-  # TODO: These should also include the ability to set the target architecture.
   @impl true
   def before_all!(:windows32) do
     [run_vcvarsall("x86")]

--- a/lib/bundlex/toolchain/visual_studio.ex
+++ b/lib/bundlex/toolchain/visual_studio.ex
@@ -16,9 +16,6 @@ defmodule Bundlex.Toolchain.VisualStudio do
   alias Bundlex.Native
   alias Bundlex.Output
 
-  @program_files System.get_env("ProgramFiles(x86)") |> Path.expand()
-  @directory_root Path.join([@program_files, "Microsoft Visual Studio"])
-
   # TODO: These should also include the ability to set the target architecture.
   @impl true
   def before_all!(:windows32) do
@@ -66,8 +63,11 @@ defmodule Bundlex.Toolchain.VisualStudio do
 
   # Runs vcvarsall.bat script
   defp run_vcvarsall(vcvarsall_arg) do
+    program_files = System.get_env("ProgramFiles(x86)") |> Path.expand()
+    directory_root = Path.join([program_files, "Microsoft Visual Studio"])
+
     vcvarsall_path =
-      @directory_root
+      directory_root
       |> build_vcvarsall_path()
 
     case File.exists?(vcvarsall_path) do

--- a/lib/bundlex/toolchain/visual_studio.ex
+++ b/lib/bundlex/toolchain/visual_studio.ex
@@ -59,25 +59,26 @@ defmodule Bundlex.Toolchain.VisualStudio do
 
     output_path = Toolchain.output_path(native.app, native.name, interface)
 
-    commands = case native do
-      %Native{type: :native, interface: :nif} ->
-        [
-          "(cl #{compile_options} #{includes_part} #{sources_part})",
-          ~s[(link #{link_options} #{libs_part} /DLL /OUT:"#{PathHelper.fix_slashes(output_path)}.dll" *.obj)]
-        ]
+    commands =
+      case native do
+        %Native{type: :native, interface: :nif} ->
+          [
+            "(cl #{compile_options} #{includes_part} #{sources_part})",
+            ~s[(link #{link_options} #{libs_part} /DLL /OUT:"#{PathHelper.fix_slashes(output_path)}.dll" *.obj)]
+          ]
 
-      %Native{type: :lib} ->
-        [
-          "(cl #{compile_options} #{includes_part} #{sources_part})",
-          ~s[(lib /OUT:"#{PathHelper.fix_slashes(output_path)}.lib" *.obj)]
-        ]
+        %Native{type: :lib} ->
+          [
+            "(cl #{compile_options} #{includes_part} #{sources_part})",
+            ~s[(lib /OUT:"#{PathHelper.fix_slashes(output_path)}.lib" *.obj)]
+          ]
 
-      %Native{type: type, interface: :nif} when type in [:cnode, :port] ->
-        [
-          "(cl #{compile_options} #{includes_part} #{sources_part})",
-          ~s[(link /libpath:"#{:code.root_dir() |> Path.join("lib/erl_interface-5.5.2/lib") |> PathHelper.fix_slashes()}" #{link_options} #{libs_part} /OUT:"#{PathHelper.fix_slashes(output_path)}.exe" *.obj)]
-        ]
-    end
+        %Native{type: type, interface: :nif} when type in [:cnode, :port] ->
+          [
+            "(cl #{compile_options} #{includes_part} #{sources_part})",
+            ~s[(link /libpath:"#{:code.root_dir() |> Path.join("lib/erl_interface-5.5.2/lib") |> PathHelper.fix_slashes()}" #{link_options} #{libs_part} /OUT:"#{PathHelper.fix_slashes(output_path)}.exe" *.obj)]
+          ]
+      end
 
     [
       "(if exist #{dir_part} rmdir /S /Q #{dir_part})",
@@ -112,10 +113,11 @@ defmodule Bundlex.Toolchain.VisualStudio do
   defp build_vcvarsall_path(root) do
     vswhere = Path.join([root, "Installer", "vswhere.exe"])
     vswhere_args = ["-property", "installationPath", "-latest"]
+
     with true <- File.exists?(vswhere),
-         {maybe_installation_path, 0} <- System.cmd(vswhere, vswhere_args)
-    do
+         {maybe_installation_path, 0} <- System.cmd(vswhere, vswhere_args) do
       installation_path = String.trim(maybe_installation_path)
+
       Path.join([installation_path, "VC", "Auxiliary", "Build", "vcvarsall.bat"])
       |> PathHelper.fix_slashes()
     end

--- a/test/bundlex/integration_test.exs
+++ b/test/bundlex/integration_test.exs
@@ -51,10 +51,16 @@ defmodule Bundlex.IntegrationTest do
             | env
           ]
 
+        family = Bundlex.family()
+        {cmd, arg} = case family do
+          f when f in [:unix, :custom] -> {"sh", "-c"}
+          :windows -> {"cmd", "/c"}
+        end
+
         assert {_output, 0} =
                  System.cmd(
-                   "sh",
-                   ["-c", "#{proj_cmd} 1>&2"],
+                   cmd,
+                   [arg, "#{proj_cmd} 1>&2"],
                    [cd: project, env: env] ++ opts
                  )
 

--- a/test/bundlex/integration_test.exs
+++ b/test/bundlex/integration_test.exs
@@ -52,10 +52,12 @@ defmodule Bundlex.IntegrationTest do
           ]
 
         family = Bundlex.family()
-        {cmd, arg} = case family do
-          f when f in [:unix, :custom] -> {"sh", "-c"}
-          :windows -> {"cmd", "/c"}
-        end
+
+        {cmd, arg} =
+          case family do
+            f when f in [:unix, :custom] -> {"sh", "-c"}
+            :windows -> {"cmd", "/c"}
+          end
 
         assert {_output, 0} =
                  System.cmd(


### PR DESCRIPTION
This is my (mostly) minimal set of changes to get Windows compilation working. There's still a couple things I want to add to this (cross-architecture compilation, maybe ability to pass different options to `vswhere`, etc.), but this is enough, I think, for one to compile a simple Bundlex app on Windows for Windows.

One thing of note is the use of `vswhere` itself. As far as I understand, it's been the preferred way to find Visual Studio-related locations for various things since Visual Studio 2017, so I think it's within the realm of general availability. I could add back the option for an environment variable, but I believe the intent for Windows development is to modify the paths in a way where `vswhere` can still find them? I haven't done any Windows development since before VS 2017 came out, so I'm not sure. If there are any Windows experts that can chime in, that would help.