### PR TITLE
Adds error thrown for missing vswhere

### DIFF
--- a/lib/bundlex/toolchain/visual_studio.ex
+++ b/lib/bundlex/toolchain/visual_studio.ex
@@ -114,12 +114,16 @@ defmodule Bundlex.Toolchain.VisualStudio do
     vswhere = Path.join([root, "Installer", "vswhere.exe"])
     vswhere_args = ["-property", "installationPath", "-latest"]
 
-    with true <- File.exists?(vswhere),
-         {maybe_installation_path, 0} <- System.cmd(vswhere, vswhere_args) do
-      installation_path = String.trim(maybe_installation_path)
+    case {File.exists?(vswhere), System.cmd(vswhere, vswhere_args)} do
+      {true, {maybe_installation_path, 0}} ->
+        installation_path = String.trim(maybe_installation_path)
 
-      Path.join([installation_path, "VC", "Auxiliary", "Build", "vcvarsall.bat"])
-      |> PathHelper.fix_slashes()
+        Path.join([installation_path, "VC", "Auxiliary", "Build", "vcvarsall.bat"])
+        |> PathHelper.fix_slashes()
+
+      {false, _} ->
+        Output.raise("Unable to find vswhere.exe at #{vswhere}. Is Visual Studio installed correctly?")
     end
+
   end
 end

--- a/lib/bundlex/toolchain/visual_studio.ex
+++ b/lib/bundlex/toolchain/visual_studio.ex
@@ -114,16 +114,17 @@ defmodule Bundlex.Toolchain.VisualStudio do
     vswhere = Path.join([root, "Installer", "vswhere.exe"])
     vswhere_args = ["-property", "installationPath", "-latest"]
 
-    case {File.exists?(vswhere), System.cmd(vswhere, vswhere_args)} do
-      {true, {maybe_installation_path, 0}} ->
-        installation_path = String.trim(maybe_installation_path)
+    with true <- File.exists?(vswhere),
+         {maybe_installation_path, 0} <- System.cmd(vswhere, vswhere_args) do
+      installation_path = String.trim(maybe_installation_path)
 
-        Path.join([installation_path, "VC", "Auxiliary", "Build", "vcvarsall.bat"])
-        |> PathHelper.fix_slashes()
-
-      {false, _} ->
+      Path.join([installation_path, "VC", "Auxiliary", "Build", "vcvarsall.bat"])
+      |> PathHelper.fix_slashes()
+    else
+      false ->
         Output.raise("Unable to find vswhere.exe at #{vswhere}. Is Visual Studio installed correctly?")
+      {_output, return_value} ->
+        Output.raise("vswhere.exe failed with status #{return_value}. Unable to locate Visual Studio installation.")
     end
-
   end
 end

--- a/lib/bundlex/toolchain/visual_studio.ex
+++ b/lib/bundlex/toolchain/visual_studio.ex
@@ -122,9 +122,14 @@ defmodule Bundlex.Toolchain.VisualStudio do
       |> PathHelper.fix_slashes()
     else
       false ->
-        Output.raise("Unable to find vswhere.exe at #{vswhere}. Is Visual Studio installed correctly?")
+        Output.raise(
+          "Unable to find vswhere.exe at #{vswhere}. Is Visual Studio installed correctly?"
+        )
+
       {_output, return_value} ->
-        Output.raise("vswhere.exe failed with status #{return_value}. Unable to locate Visual Studio installation.")
+        Output.raise(
+          "vswhere.exe failed with status #{return_value}. Unable to locate Visual Studio installation."
+        )
     end
   end
 end


### PR DESCRIPTION
Provides context for missing vswhere.exe error in the event a user does not have it installed. 

Addresses: 

https://github.com/membraneframework/membrane_core/issues/942