### PR TITLE
Fix load function to prevent errors when re-evaluated ElixirLS

### DIFF
--- a/lib/bundlex/project.ex
+++ b/lib/bundlex/project.ex
@@ -193,7 +193,9 @@ defmodule Bundlex.Project do
   defp load(application) do
     with {:ok, dir} <- MixHelper.get_project_dir(application) do
       bundlex_file_path = dir |> Path.join(@bundlex_file_name)
-      modules = Code.require_file(bundlex_file_path) |> Keyword.keys()
+      modules =
+        (Code.require_file(bundlex_file_path) || Code.compile_file(bundlex_file_path))
+        |> Keyword.keys()
 
       modules
       |> Enum.find(&project_module?/1)

--- a/lib/bundlex/project.ex
+++ b/lib/bundlex/project.ex
@@ -194,7 +194,7 @@ defmodule Bundlex.Project do
     with {:ok, dir} <- MixHelper.get_project_dir(application) do
       bundlex_file_path = dir |> Path.join(@bundlex_file_name)
       modules =
-        (Code.require_file(bundlex_file_path) || Code.compile_file(bundlex_file_path))
+        Code.compile_file(bundlex_file_path)
         |> Keyword.keys()
 
       modules


### PR DESCRIPTION
Attempt to resolve a re-evaluation error in `Bundlex.Project.load/1` where the function will fail if called more than once in the same session.

`Code.require_file/1` returns `{module, bytecode}` tuples on the first call, but returns `nil` on subsequent calls.  When ElixirLS triggers a recompile in the same session, `Code.require_file/1` returns `nil`.

```
an exception was raised:
    ** (FunctionClauseError) no function clause matching in Keyword.keys/1
        (elixir 1.19.5) lib/keyword.ex:652: Keyword.keys(nil)
        (bundlex 1.5.4) lib/bundlex/project.ex:196: Bundlex.Project.load/1
        (bundlex 1.5.4) lib/bundlex/project.ex:175: Bundlex.Project.get/1
        (bundlex 1.5.4) lib/mix/tasks/compile.bundlex.ex:29: Mix.Tasks.Compile.Bundlex.run/1
        (mix 1.19.5) lib/mix/task.ex:499: anonymous fn/3 in Mix.Task.run_task/5
        (mix 1.19.5) lib/mix/task.compiler.ex:299: Mix.Task.Compiler.run_compiler/2
        (mix 1.19.5) lib/mix/task.compiler.ex:287: Mix.Task.Compiler.run/4
        (mix 1.19.5) lib/mix/tasks/compile.all.ex:75: Mix.Tasks.Compile.All.do_run/2
        (mix 1.19.5) lib/mix/sync/lock.ex:122: Mix.Sync.Lock.with_lock/3
        (mix 1.19.5) lib/mix/task.ex:499: anonymous fn/3 in Mix.Task.run_task/5
        (mix 1.19.5) lib/mix/tasks/compile.ex:145: Mix.Tasks.Compile.run/1
        (mix 1.19.5) lib/mix/task.ex:499: anonymous fn/3 in Mix.Task.run_task/5
        (language_server 0.30.0) lib/language_server/build.ex:566: ElixirLS.LanguageServer.Build.run_mix_compile/1
        (language_server 0.30.0) lib/language_server/build.ex:198: ElixirLS.LanguageServer.Build.handle_compile_phase/6
        (stdlib 7.2) timer.erl:599: :timer.tc/2
        (language_server 0.30.0) lib/language_server/build.ex:22: anonymous fn/3 in ElixirLS.LanguageServer.Build.build/3
```

Not sure I am approaching fixing this problem appropriately, it feels quite hack-ish as-is.  Please let me know what you think.